### PR TITLE
Ask employee questions rename

### DIFF
--- a/server.js
+++ b/server.js
@@ -245,12 +245,12 @@ function returnManagerArray() {
                 for (let i = 0; i < data.length; i++) {
                     managerArray.push(data[i].manager_full_name)
                 }
-                askEmployeeQuestions(roleArray, managerArray);
+                addEmployeeQuestions(roleArray, managerArray);
             })
     }
 };
 
-function askEmployeeQuestions() {
+function addEmployeeQuestions() {
     inquirer.prompt([
         {
             type: "input",


### PR DESCRIPTION
This update changes the function `askEmployeeQuestions` to `addEmployeeQuestions` for continuity between the other main menu-related functions which match their respective choice names.